### PR TITLE
@types/deep-equal: fix missing default export

### DIFF
--- a/types/deep-equal/deep-equal-tests.ts
+++ b/types/deep-equal/deep-equal-tests.ts
@@ -1,4 +1,4 @@
-import deepEqual = require("deep-equal");
+import deepEqual from "deep-equal";
 
 const isDeepEqual1: boolean = deepEqual({}, {});
 const isDeepEqual2: boolean = deepEqual({}, {}, { strict: true });

--- a/types/deep-equal/index.d.ts
+++ b/types/deep-equal/index.d.ts
@@ -12,4 +12,4 @@ declare function deepEqual(
     expected: any,
     opts?: DeepEqualOptions): boolean;
 
-export = deepEqual;
+export default deepEqual;


### PR DESCRIPTION
Without a default export, there is no way to import `deepEqual` in Angular 6. The import needed with the current code is

    import deepEqual = require('deep-equal');

and leads to the error

    error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.

The correct import is now:

    import deepEqual from 'deep-equal';

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint deep-lint` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
